### PR TITLE
added architecture-specific android builds to reduce APK size 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '25'
+          java-version: '22'
       - uses: subosito/flutter-action@v2
         with:
           flutter-version: '3.38.5'


### PR DESCRIPTION
- split Android builds by architecture (arm64-v8a, armeabi-v7a, x86_64) using `--split-per-abi`
- changed Java version (now using 22)
- updated naming: `apk` → `android-apks`, `rdnbenet.zip` → `rdnbenet-linux-x64.zip`
- upgraded GitHub Actions from v2 to v3/v4

 tested on my fork - all builds were successful